### PR TITLE
fix complete callback inconsistency in 'changes'

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/changes.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/changes.js
@@ -42,7 +42,7 @@ export default function (db, api, opts) {
       return true
     })
 
-    if (filterSeqs.length === 0) return complete(null, [])
+    if (filterSeqs.length === 0) return complete(null, { results: [] })
 
     db.storage.multiGet(toSequenceKeys(filterSeqs), (error, dataDocs) => {
       if (error) return complete(error)
@@ -50,7 +50,7 @@ export default function (db, api, opts) {
       const filterDocs = filterDocIds
         ? dataDocs.filter(doc => filterDocIds.has(doc._id))
         : dataDocs
-      if (filterDocs.length === 0) return complete(null, [])
+      if (filterDocs.length === 0) return complete(null, { results: [] })
 
       const changeDocIds = [...new Set(
         filterDocs.map(data => forDocument(data._id)))]


### PR DESCRIPTION
I've got the `Cannot read property 'length' of undefined` error in the line https://github.com/pouchdb/pouchdb/blob/4cd2a1fa88a8b3de0f4dfe731620c89d46e1c5d8/packages/node_modules/pouchdb-mapreduce/src/index.js#L508 from package `pouchdb-mapreduce` when calling `query` function. 

It expects `complete` callback to be an object with the `results` property like the few lines below https://github.com/stockulus/pouchdb-react-native/blob/567a2423808a54f7cf6bc7ea891f27995260aae3/packages/pouchdb-adapter-asyncstorage/src/changes.js#L93-L96  