### PR TITLE
Include a subset of the integration tests to CI, downgrade mocha version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,22 @@
 language: node_js
 node_js:
   - "6"
+sudo: required
+services:
+  - docker
+before_install:
+  - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
+before_script:
+  - sh pouchdb-original/bin/run-couchdb-on-travis.sh
+env:
+  - COMMAND="npm test"
+matrix:
+  include:
+    - services: docker
+      env: COMMAND="npm run test-integration"
+    - services: docker
+      env: COMMAND="npm run test-mapreduce"
+  allow_failures:
+    - env: COMMAND="npm run test-integration"
+    - env: COMMAND="npm run test-mapreduce"
+script: $COMMAND

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "offlinefirst"
   ],
   "scripts": {
-    "test": "npm run standard && npm run test-unit",
+    "test": "npm run standard && npm run test-unit && npm run test-integration-subset",
     "test-unit": "mocha -r tests/setup.js pouchdb-original/tests/unit/test.*.js",
-    "test-mapreduce": "mocha -r tests/setup.js pouchdb-original/tests/mapreduce/test.*.js",
-    "test-integration": "mocha -r tests/setup.js pouchdb-original/tests/integration/test.*.js",
+    "test-mapreduce": "COUCH_HOST=http://localhost:3000 mocha -r tests/setup.js pouchdb-original/tests/mapreduce/test.*.js",
+    "test-integration": "COUCH_HOST=http://localhost:3000 mocha -r tests/setup.js pouchdb-original/tests/integration/test.*.js",
+    "test-integration-subset": "COUCH_HOST=http://localhost:3000 ./tests/run-integration.sh",
     "standard": "node ./node_modules/standard/bin/cmd.js",
     "clean": "rm -rf packages/**/node_modules && rm -rf ./example/node_modules && rm -rf ./pouchdb-original/node_modules && rm -rf ./node_modules",
     "postinstall": "for D in ./packages/*; do cd $D; npm install; cd -; done && cd example && npm install && cd ../pouchdb-original && npm install",
@@ -35,7 +36,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "6.14.0",
-    "mocha": "3.0.2",
+    "mocha": "2.5.3",
     "react": "15.3.1",
     "react-native": "0.33.0",
     "react-native-mock": "0.2.6",

--- a/tests/find-integration-passed.sh
+++ b/tests/find-integration-passed.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for test in pouchdb-original/tests/integration/test.*.js;
+do
+  node_modules/.bin/mocha --timeout 5000 -r tests/setup.js $test &> /dev/null
+
+  if [[ $? == 0 ]]; then
+    echo $test
+  fi
+done

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+PASS=(
+  pouchdb-original/tests/integration/test.ajax.js
+  pouchdb-original/tests/integration/test.all_docs.js
+  pouchdb-original/tests/integration/test.bulk_get.js
+  pouchdb-original/tests/integration/test.constructor.js
+  pouchdb-original/tests/integration/test.defaults.js
+  pouchdb-original/tests/integration/test.http.js
+  pouchdb-original/tests/integration/test.issue1175.js
+  pouchdb-original/tests/integration/test.node-websql.js
+  pouchdb-original/tests/integration/test.replicationBackoff.js
+  pouchdb-original/tests/integration/test.setup_global_hooks.js
+  pouchdb-original/tests/integration/test.uuids.js
+)
+
+node_modules/.bin/mocha --timeout 5000 -r tests/setup.js ${PASS[@]}


### PR DESCRIPTION
## mocha

The main `pouchdb` repo uses 2.5.3 https://github.com/pouchdb/pouchdb/blob/91223218c11ef4a555d4c542274379adf4765c6a/package.json#L89 Few tests were failing solely due to incompatible API with 3.0.2

## tests

I've written `tests/find-integration-passed.sh` to test which test files are fully passed so they could be included in the CI routine to prevent regressions. 

Also, Travis is now configured to additionally test all of the tests without affecting build status (`matrix` / `allow_failures`) to see how much of the failing tests still there. 