### PR TITLE
Fix views by filtering local keys

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/keys.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/keys.js
@@ -23,7 +23,7 @@ export const toMetaKeys = list => list.map(forMeta)
 export const toSequenceKeys = list => list.map(forSequence)
 
 export const getDocumentKeys = list => list
-  .filter(key => key.startsWith(DOC_STORE))
+  .filter(key => key.startsWith(DOC_STORE) && !key.startsWith(`${DOC_STORE}_local`))
   .map(key => key.slice(DOC_STORE_LENGTH))
 
 export const getSequenceKeys = list => list

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -6,11 +6,13 @@ PASS=(
   pouchdb-original/tests/integration/test.bulk_get.js
   pouchdb-original/tests/integration/test.constructor.js
   pouchdb-original/tests/integration/test.defaults.js
+  pouchdb-original/tests/integration/test.design_docs.js
   pouchdb-original/tests/integration/test.http.js
   pouchdb-original/tests/integration/test.issue1175.js
   pouchdb-original/tests/integration/test.node-websql.js
   pouchdb-original/tests/integration/test.replicationBackoff.js
   pouchdb-original/tests/integration/test.setup_global_hooks.js
+  pouchdb-original/tests/integration/test.taskqueue.js
   pouchdb-original/tests/integration/test.uuids.js
 )
 


### PR DESCRIPTION
You could add commit with a proper solution directly in this pull request https://github.com/blog/2247-improving-collaboration-with-forks 

My use case: 

```js
const db = new PouchDB(dbs.name)
const indexName = 'my_index'
const ddoc = {
  _id: `_design/${indexName}`,
  views: {
    [indexName]: {
      map: function (doc) {
        emit(doc.name)
      }.toString()
    }
  }
}

return db
  .put(ddoc)
  .then(() => {
    return db.put({ _id: '1', name: 'test' })
  })
  .then(() => {
    return db.query(`${indexName}`, { include_docs: true })
  })
  .then(items => {
    console.log(items)
 })
```

It was throwing exceptions from the `pouchdb-collate` package before, I've checked it and there were weird docs with 'ÿdocument-storeÿ_local' prefix in ids which couldn't be processed. So a simple filter addition somehow fixes views and doesn't break the previously passed tests. 

Any inside where do these docs come from?  