### PR TITLE
Fix wrong rev picking on replication, fixes #40

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/all_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/all_docs.js
@@ -31,7 +31,7 @@ export default function (db, opts, callback) {
       key: doc.id,
       value: {
         deleted: doc.deleted,
-        rev: doc.rev
+        rev: doc.winningRev
       }
     }
 
@@ -39,7 +39,7 @@ export default function (db, opts, callback) {
       result.doc = {
         ...doc.data,
         _id: doc.id,
-        _rev: doc.rev
+        _rev: doc.winningRev
       }
 
       if (includeConflicts) {
@@ -102,7 +102,9 @@ const getDocs = (db,
       if (skip > 0) result = result.slice(skip)
       if (limit >= 0 && result.length > limit) result = result.slice(0, limit)
 
-      let seqKeys = result.map(item => forSequence(item.seq))
+      let seqKeys = result.map(item => {
+        return forSequence(item.rev_map[item.winningRev])
+      })
       db.storage.multiGet(seqKeys, (error, dataDocs) => {
         if (error) return callback(error)
 

--- a/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
@@ -5,7 +5,7 @@ import {
   generateErrorFromResponse,
   BAD_ARG, BAD_REQUEST, MISSING_DOC, MISSING_STUB, REV_CONFLICT } from 'pouchdb-errors'
 import { parseDoc } from 'pouchdb-adapter-utils'
-import { merge } from 'pouchdb-merge'
+import { merge, winningRev as computeWinningRev } from 'pouchdb-merge'
 import Md5 from 'spark-md5'
 
 import { forDocument, forAttachment, forMeta, forSequence } from './keys'
@@ -126,8 +126,8 @@ export default function (db, req, opts, callback) {
 
       newDoc.seq = ++newMeta.update_seq
       newDoc.rev_map = oldDoc.rev_map
+      newDoc.winningRev = computeWinningRev(newDoc)
       newDoc.rev_map[newDoc.rev] = newDoc.seq
-      newDoc.winningRev = newDoc.rev
 
       const data = newDoc.deleted ? {_deleted: true} : newDoc.data
       delete newDoc.data
@@ -150,7 +150,7 @@ export default function (db, req, opts, callback) {
       newDoc.seq = ++newMeta.update_seq
       newDoc.rev_map = {}
       newDoc.rev_map[newDoc.rev] = newDoc.seq
-      newDoc.winningRev = newDoc.rev
+      newDoc.winningRev = computeWinningRev(newDoc)
       if (!newDoc.deleted) newMeta.doc_count ++
 
       const data = newDoc.data

--- a/packages/pouchdb-adapter-asyncstorage/src/get.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/get.js
@@ -4,6 +4,7 @@ import {
   createError,
   MISSING_DOC } from 'pouchdb-errors'
 import { forDocument, forSequence } from './keys'
+import { winningRev } from 'pouchdb-merge'
 
 export default function (db, id, opts, callback) {
   db.storage.get(forDocument(id), (error, meta) => {
@@ -14,7 +15,7 @@ export default function (db, id, opts, callback) {
       return callback(createError(MISSING_DOC, 'missing-no-meta-found'))
     }
 
-    const rev = opts.rev || (meta && meta.rev)
+    const rev = opts.rev || winningRev(meta)
     if (!meta || (meta.deleted && !opts.rev) || !(rev in meta.rev_map)) {
       return callback(createError(MISSING_DOC, 'missing-rev-check'))
     }

--- a/tests/find-integration-passed.sh
+++ b/tests/find-integration-passed.sh
@@ -2,7 +2,7 @@
 
 for test in pouchdb-original/tests/integration/test.*.js;
 do
-  node_modules/.bin/mocha --timeout 5000 -r tests/setup.js $test &> /dev/null
+  COUCH_HOST=http://localhost:3000 node_modules/.bin/mocha --timeout 5000 -r tests/setup.js $test &> /dev/null
 
   if [[ $? == 0 ]]; then
     echo $test

--- a/tests/integration/issue-40.js
+++ b/tests/integration/issue-40.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/* global describe, it, PouchDB */
+describe('pouchdb-react-native issue#40', function () {
+  it('similar results after syncing in different order', function () {
+    const sourceDb1 = new PouchDB('sourceDb1')
+    const sourceDb2 = new PouchDB('sourceDb2')
+    const localDest1 = new PouchDB('localDest')
+    const localDest2 = new PouchDB('localDest2')
+
+    return Promise
+      .resolve()
+      .then(() => Promise
+        .all([
+          sourceDb1.put({ _id: '1', foo: 'bar' }),
+          sourceDb2.put({ _id: '1', bar: 'baz' })
+        ])
+      )
+      .then(() => Promise
+        .all([
+          sourceDb1.replicate.to(localDest1),
+          sourceDb2.replicate.to(localDest1),
+          sourceDb2.replicate.to(localDest2),
+          sourceDb1.replicate.to(localDest2)
+        ])
+      )
+      .then(() => Promise
+        .all([
+          sourceDb1.get('1'),
+          sourceDb2.get('1'),
+          localDest1.get('1'),
+          localDest2.get('1')
+        ])
+      )
+      .then(([ sourceDoc1, sourceDoc2, destDoc1, destDoc2 ]) => {
+        sourceDoc1._rev.should.not.equal(sourceDoc2._rev, 'Source docs need different revs for test to work')
+        destDoc1._rev.should.equal(destDoc2._rev, 'Destination docs have different revs')
+
+        return Promise
+          .all([
+            localDest1.allDocs(),
+            localDest2.allDocs()
+          ])
+      })
+      .then(([ res1, res2 ]) => {
+        res1.rows[0].value.rev.should.equal(res2.rows[0].value.rev, 'allDocs should be equal')
+      })
+  })
+})

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 PASS=(
-  pouchdb-original/tests/integration/test.ajax.js
   pouchdb-original/tests/integration/test.all_docs.js
   pouchdb-original/tests/integration/test.bulk_get.js
   pouchdb-original/tests/integration/test.constructor.js
@@ -9,9 +8,13 @@ PASS=(
   pouchdb-original/tests/integration/test.design_docs.js
   pouchdb-original/tests/integration/test.http.js
   pouchdb-original/tests/integration/test.issue1175.js
+  pouchdb-original/tests/integration/test.issue221.js
   pouchdb-original/tests/integration/test.node-websql.js
   pouchdb-original/tests/integration/test.replicationBackoff.js
+  pouchdb-original/tests/integration/test.replication_events.js
   pouchdb-original/tests/integration/test.setup_global_hooks.js
+  pouchdb-original/tests/integration/test.slash_id.js
+  pouchdb-original/tests/integration/test.sync_events.js
   pouchdb-original/tests/integration/test.taskqueue.js
   pouchdb-original/tests/integration/test.uuids.js
 )


### PR DESCRIPTION
Relevant parts from stable adapters (a.k.a. how I found what's wrong), fixes #40:

## `get`
https://github.com/pouchdb/pouchdb/blob/d2dab5ac3c464ba3db4d5c20a93fbdda12940740/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js#L374

## `bulkDocs`
https://github.com/pouchdb/pouchdb/blob/d2dab5ac3c464ba3db4d5c20a93fbdda12940740/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js#L835
https://github.com/pouchdb/pouchdb/blob/d2dab5ac3c464ba3db4d5c20a93fbdda12940740/packages/node_modules/pouchdb-adapter-utils/src/processDocs.js#L23

---

Also, +4 integration tests but not sure whether it is this change or previous