### PR TITLE
Added Blob attachment support for when syncing from remote server

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
@@ -54,7 +54,7 @@ export default function (db, req, opts, callback) {
         })
       }
 
-      let resolveBinaryData;
+      let resolveBinaryData
       if (typeof attachment.data === 'string') {
         let binData = parseBase64(attachment.data)
         if (binData.error) {
@@ -65,19 +65,19 @@ export default function (db, req, opts, callback) {
         resolveBinaryData = Promise.resolve({
           data: binData,
           size: binData.size || binData.length || 0
-        });
+        })
 
       } else if (typeof attachment.data === 'object') {  // Support for BLOB attachments
         resolveBinaryData = new Promise((resolve, reject) => {
           readAsArrayBuffer(attachment.data, (binData) => {
             const arrayBufferToBase64 = (buffer) => {
-              let binary = '';
-              const bytes = new Uint8Array(buffer);
-              const len = bytes.byteLength;
+              let binary = ''
+              const bytes = new Uint8Array(buffer)
+              const len = bytes.byteLength
               for (let i = 0; i < len; i++) {
-                binary += String.fromCharCode(bytes[i]);
+                binary += String.fromCharCode(bytes[i])
               }
-              return binary;
+              return binary
             }
 
             return resolve({
@@ -90,7 +90,7 @@ export default function (db, req, opts, callback) {
         resolveBinaryData = Promise.resolve({
           data: attachment.data,
           size: attachment.data.size || attachment.data.length || 0
-        });
+        })
       }
 
       return resolveBinaryData

--- a/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
@@ -66,8 +66,7 @@ export default function (db, req, opts, callback) {
           data: binData,
           size: binData.size || binData.length || 0
         })
-
-      } else if (typeof attachment.data === 'object') {  // Support for BLOB attachments
+      } else if (typeof attachment.data === 'object') {
         resolveBinaryData = new Promise((resolve, reject) => {
           readAsArrayBuffer(attachment.data, (binData) => {
             const arrayBufferToBase64 = (buffer) => {
@@ -79,7 +78,6 @@ export default function (db, req, opts, callback) {
               }
               return binary
             }
-
             return resolve({
               data: arrayBufferToBase64(binData),
               size: attachment.data.size || attachment.data.length || 0


### PR DESCRIPTION
This PR is to address problems with BLOB attachments during the PouchDB syncing process with a remote server like CouchDB.

The current process is to just ```global.btoa(attachment.data)``` which will always return the same string since encoding a Blob and not the content within.  This means attachments just don't work if they come as type BLOB.

The solution is to run the Blob through the FileReader and then unwrap the ArrayBuffer returned back through btoa.  This when provides a base64 string to be stored locally.

**NOTE**: This does not provide support to store BLOB attachments locally but instead support receiving remote BLOB attachments from a remote server.  All BLOB attachments will be stored as base64 locally in AsyncStorage.