### PR TITLE
Fix bulk update

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
@@ -214,7 +214,8 @@ export default function (db, req, opts, callback) {
     })
     Promise.all(promises)
       .then(changes => {
-        if (changes.length === 0) return callback(null, {})
+        changes = changes.filter(change => !!change.doc)
+        if (changes.length === 0) return callback(null, [])
 
         const dbChanges = []
         dbChanges.push([forMeta('_local_doc_count'), newMeta.doc_count])


### PR DESCRIPTION
Replication was completely failing for me because of this.
1) the callback on line 218 is supposed to return an array (see line 239 when the value is an array)
2) null changes are represented as `{}` (see line 111), which caused replication to fail at `db.storage.multiPut` because at `225` we were pushing `undefined` onto `dbChanges`

btw thanks for an awesome library!