### PR TITLE
Use safeJsonStringify instead of JSON.stringify

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/package.json
+++ b/packages/pouchdb-adapter-asyncstorage/package.json
@@ -35,6 +35,7 @@
     "left-pad": "1.1.3",
     "pouchdb-adapter-utils": "6.1.0",
     "pouchdb-errors": "6.1.0",
+    "pouchdb-json": "6.1.0",
     "pouchdb-merge": "6.1.0",
     "pouchdb-utils": "6.1.0",
     "spark-md5": "3.0.0"

--- a/packages/pouchdb-adapter-asyncstorage/src/asyncstorage_core.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/asyncstorage_core.js
@@ -8,7 +8,7 @@ import { AsyncStorage } from 'react-native'
 import {
   safeJsonParse,
   safeJsonStringify
-} from 'pouchdb-json';
+} from 'pouchdb-json'
 
 function createPrefix (dbName) {
   return dbName.replace(/!/g, '!!') + '!' // escape bangs in dbName

--- a/packages/pouchdb-adapter-asyncstorage/src/asyncstorage_core.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/asyncstorage_core.js
@@ -5,6 +5,10 @@
  */
 
 import { AsyncStorage } from 'react-native'
+import {
+  safeJsonParse,
+  safeJsonStringify
+} from 'pouchdb-json';
 
 function createPrefix (dbName) {
   return dbName.replace(/!/g, '!!') + '!' // escape bangs in dbName
@@ -48,7 +52,7 @@ const stringifyValue = value => {
   if (value === null) return ''
   if (value === undefined) return ''
 
-  return JSON.stringify(value)
+  return safeJsonStringify(value)
 }
 
 AsyncStorageCore.prototype.put = function (key, value, callback) {
@@ -64,7 +68,7 @@ AsyncStorageCore.prototype.multiPut = function (pairs, callback) {
 }
 
 const parseValue = value => {
-  if (typeof value === 'string') return JSON.parse(value)
+  if (typeof value === 'string') return safeJsonParse(value)
   return null
 }
 


### PR DESCRIPTION
See the idb backend for some more info: https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-adapter-idb/src/utils.js#L29

I was running into an `Overflow Error` at the `JSON.stringify` line, leading
to a long internet hunt to find that this has been faced & solved before.
See also:
- https://github.com/Level/levelup/issues/276
- https://github.com/pouchdb/pouchdb/pull/2723
- https://github.com/pouchdb/pouchdb/pull/3188

With this change, I no longer get the sync error.

Test Plan:
In my app :P try to sync with a doc that has a ton of revisions. It should not
fail at the `JSON.stringify` line.