### PR TITLE
Adding _remote to comply with PouchDB deprecation notice.

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/index.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/index.js
@@ -20,6 +20,7 @@ const ADAPTER_NAME = 'asyncstorage'
 function AsyncStoragePouch (dbOpts, constuctorCallback) {
   const api = this
 
+  api._remote = false
   api.type = () => ADAPTER_NAME
 
   api._id = callback => {


### PR DESCRIPTION
I was getting a lot of warnings while using the newest version of pouchdb-react-native due to db.type() being used. Checking [PouchDB's 6.2.0 release](https://github.com/pouchdb/pouchdb/releases/tag/6.2.0). I noticed the following: "deprecate .type() in favor of ._remote". Looking into [one of their adapters](https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-adapter-idb/src/index.js#L292), I noticed that, for now, they are simply adding ```api._remote = false``` to non-http adapters to comply with the deprecation notice.