### PR TITLE
Correct usage combining descending & limit

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/all_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/all_docs.js
@@ -51,12 +51,11 @@ export default function (db, opts, callback) {
   }
 
   getDocs(db,
-    {filterKey, startkey, endkey, skip, limit, excludeStart, inclusiveEnd, includeAttachments, binaryAttachments, includeDeleted},
+    {filterKey, startkey, endkey, skip, limit, excludeStart, inclusiveEnd, includeAttachments, binaryAttachments, includeDeleted, descending},
     (error, docs) => {
       if (error) return callback(generateErrorFromResponse(error))
 
       let rows = docs.map(docToRow)
-      if (descending) rows = rows.reverse()
 
       callback(null, {
         total_rows: db.meta.doc_count,
@@ -77,7 +76,8 @@ const getDocs = (db,
    inclusiveEnd,
    includeDeleted,
    includeAttachments,
-   binaryAttachments
+   binaryAttachments,
+   descending
  },
   callback) => {
   db.storage.getKeys((error, keys) => {
@@ -99,6 +99,7 @@ const getDocs = (db,
         ? docs
         : docs.filter(doc => !doc.deleted)
 
+      if (descending) result = result.reverse()
       if (skip > 0) result = result.slice(skip)
       if (limit >= 0 && result.length > limit) result = result.slice(0, limit)
 


### PR DESCRIPTION
When using descending together with limit, it should fetch the last limited docs, not the first ones.

E.g., having database with docs: [1, 2, 3, 4, 5, 6, 7, 8, 9].

`db.allDocs({descending: true, limit: 3})` currently returns [3,2,1].

With this fix, it'll correctly return [9,8,7].

It is to keep consistent with browser/node pouchdb implementation, and the couchdb behavior.