### PR TITLE
fix: last_seq lost if no changes

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/changes.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/changes.js
@@ -45,7 +45,7 @@ export default function (db, api, opts) {
       return true
     })
 
-    if (filterSeqs.length === 0) return complete(null, {results: []})
+    if (filterSeqs.length === 0) return complete(null, {last_seq: lastSeq, results: []})
 
     db.storage.multiGet(toSequenceKeys(filterSeqs), (error, dataDocs) => {
       if (error) return complete(error)
@@ -53,7 +53,7 @@ export default function (db, api, opts) {
       const filterDocs = filterDocIds
         ? dataDocs.filter(doc => filterDocIds.has(doc._id))
         : dataDocs.filter(doc => !doc._id.startsWith('_local'))
-      if (filterDocs.length === 0) return complete(null, {results: []})
+      if (filterDocs.length === 0) return complete(null, {last_seq: lastSeq, results: []})
 
       const changeDocIds = [...new Set(
         filterDocs.map(data => forDocument(data._id)))]


### PR DESCRIPTION
If there are no new `changes` given the request params, return [`lastSeq`](https://github.com/stockulus/pouchdb-react-native/blob/master/packages/pouchdb-adapter-asyncstorage/src/changes.js#L22).

This replicates PouchDB `changes` feed behaviour.

Ref #65 