### PR TITLE
Fix doc with attachment lifecycle - updating a doc with attachments that was fetched with {attachments: false} is throwing error

### DIFF
--- a/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
+++ b/packages/pouchdb-adapter-asyncstorage/src/bulk_docs.js
@@ -45,10 +45,14 @@ export default function (db, req, opts, callback) {
         return new Promise((resolve, reject) => {
           if (!attachment.digest) return reject(createError(MISSING_STUB, 'no digest'))
 
-          db.storage.get(forAttachment(attachment.digest), (error, data) => {
+          const attachmentKey = forAttachment(attachment.digest)
+          db.storage.get(attachmentKey, (error, data) => {
             if (error) return reject(createError(MISSING_STUB, error.message))
             if (!data) return reject(createError(MISSING_STUB, 'can not find attachment'))
-            return resolve({attachment, dbAttachment: []})
+            return resolve({
+              attachment,
+              dbAttachment: [attachmentKey, data]
+            })
           })
         })
       }

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -1,0 +1,63 @@
+'use strict'
+
+/* global describe, it, should, PouchDB */
+
+function buildDocAttachment (data) {
+  return {
+    _id: 'demo',
+    _attachments: {
+      'demo.txt': {
+        content_type: 'text/plain',
+        data
+      }
+    }
+  }
+}
+
+describe('attachments', function () {
+  describe('updating docs with attachments', function () {
+    it('should retrieve doc with attachment', function () {
+      const data = global.Buffer.from('some data here', 'utf8').toString('base64')
+      data.should.equal('c29tZSBkYXRhIGhlcmU=')
+
+      const utf8db = new PouchDB('getDocWithAttachments')
+      return utf8db.post(buildDocAttachment(data))
+        .then(ignore => utf8db.get('demo', { attachments: true }))
+        .then(doc => doc._attachments['demo.txt'].data.should.equal(data))
+    })
+    it('should retrieve doc with stub attachment', function () {
+      const data = global.Buffer.from('some data here', 'utf8').toString('base64')
+      data.should.equal('c29tZSBkYXRhIGhlcmU=')
+
+      const utf8db = new PouchDB('getDocWithoutAttachments')
+      return utf8db.post(buildDocAttachment(data))
+        .then(ignore => utf8db.get('demo', { attachments: false }))
+        .then(doc => {
+          should.not.exist(doc._attachments['demo.txt'].data)
+          doc._attachments['demo.txt'].stub.should.equal(true)
+        })
+    })
+    it('should keep attachments when updating a doc fetched with attachments', function () {
+      const data = global.Buffer.from('some data here', 'utf8').toString('base64')
+      data.should.equal('c29tZSBkYXRhIGhlcmU=')
+
+      const utf8db = new PouchDB('getDocWithAttachmentsAndUpdate')
+      return utf8db.post(buildDocAttachment(data))
+        .then(ignore => utf8db.get('demo', { attachments: true }))
+        .then(doc => utf8db.put({ ...doc, title: 'add some new data' }))
+        .then(() => utf8db.get('demo', { attachments: true }))
+        .then(doc => doc._attachments['demo.txt'].data.should.equal(data))
+    })
+    it('should keep attachments when updating a doc fetched without attachments', function () {
+      const data = global.Buffer.from('some data here', 'utf8').toString('base64')
+      data.should.equal('c29tZSBkYXRhIGhlcmU=')
+
+      const utf8db = new PouchDB('getDocWithoutAttachmentsAndUpdate')
+      return utf8db.post(buildDocAttachment(data))
+        .then(ignore => utf8db.get('demo', { attachments: false }))
+        .then(doc => utf8db.put({ ...doc, title: 'add some new data' }))
+        .then(() => utf8db.get('demo', { attachments: true }))
+        .then(doc => doc._attachments['demo.txt'].data.should.equal(data))
+    })
+  })
+})


### PR DESCRIPTION
Fix doc with attachment lifecycle - updating a doc with attachments that was fetched with {attachments: false} is throwing error

 - Users can db.get(id, { attachments: false }).then(doc => db.put(doc)) without error
 - Added tests that prove failure before this change and success after this change