### PR TITLE
Replication tests - add additional test coverage for Attachments

### DIFF
--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,17 @@
+
+export const couchHost = () => {
+  if (typeof window !== 'undefined' && window.cordova) {
+    // magic route to localhost on android emulator
+    return 'http://10.0.2.2:5984'
+  }
+
+  if (typeof window !== 'undefined' && window.COUCH_HOST) {
+    return window.COUCH_HOST
+  }
+
+  if (typeof process !== 'undefined' && process.env.COUCH_HOST) {
+    return process.env.COUCH_HOST
+  }
+
+  return 'http://localhost:5984'
+}


### PR DESCRIPTION
This PR just adds two replication tests for completeness.

### Current node.js Attachment coverage:

  attachments
    add b64
      ✓ should support inline post
      ✓ should support inline put
      ✓ should support many inline attachments at once (55ms)
      ✓ should support putAttachment
      ✓ should fail on empty attachment
    add binary
      ✓ should support inline post
      ✓ should support inline put
      ✓ should support many inline attachments at once (67ms)
      ✓ should support putAttachment
    get
      ✓ should support getAttachment - ensure returns binary
    updating docs with attachments
      ✓ should retrieve doc with attachment
      ✓ should retrieve doc with stub attachment
      ✓ should keep attachments when updating a doc fetched with attachments
      ✓ should keep attachments when updating a doc fetched without attachments
    replication
      ✓ should push local attachments to remote (165ms)
      ✓ should pull remote attachments to local (109ms)